### PR TITLE
Introduce persistence layer.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,15 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/samples/customers/persistence/CustomerEntity.java
+++ b/src/main/java/com/samples/customers/persistence/CustomerEntity.java
@@ -1,0 +1,37 @@
+package com.samples.customers.persistence;
+
+import com.samples.customers.domain.CustomerState;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity(name = "Customer") // Name im JPQL
+@Table(name = "CUSTOMERS") // DB-Schema
+public class CustomerEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private UUID uuid;
+  @NotNull
+  @Size(min = 3, max = 100)
+  private String name;
+  @NotNull
+  @Past
+  @Column(name = "BIRTH_DATE")
+  private LocalDate birthdate;
+  private CustomerState state = CustomerState.ACTIVE;
+
+}

--- a/src/main/java/com/samples/customers/persistence/CustomerEntityMapper.java
+++ b/src/main/java/com/samples/customers/persistence/CustomerEntityMapper.java
@@ -1,0 +1,41 @@
+package com.samples.customers.persistence;
+
+import com.samples.customers.domain.Customer;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomerEntityMapper {
+
+  public CustomerEntity map(Customer source) {
+    if (null == source) {
+      return null;
+    }
+    var target = new CustomerEntity();
+    target.setUuid(source.getUuid());
+    target.setName(source.getName());
+    target.setBirthdate(source.getBirthdate());
+    target.setState(source.getState());
+    return target;
+  }
+
+  public Customer map(CustomerEntity source) {
+    if (null == source) {
+      return null;
+    }
+    var target = new Customer();
+    target.setUuid(source.getUuid());
+    target.setName(source.getName());
+    target.setBirthdate(source.getBirthdate());
+    target.setState(source.getState());
+    return target;
+  }
+
+  public void copy(CustomerEntity source, Customer target) {
+    target.setUuid(source.getUuid());
+    target.setName(source.getName());
+    target.setBirthdate(source.getBirthdate());
+    target.setState(source.getState());
+  }
+
+
+}

--- a/src/main/java/com/samples/customers/persistence/CustomerEntityRepository.java
+++ b/src/main/java/com/samples/customers/persistence/CustomerEntityRepository.java
@@ -1,0 +1,17 @@
+package com.samples.customers.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface CustomerEntityRepository
+  extends JpaRepository<CustomerEntity, UUID> {
+
+//  List<CustomerEntity> findAllByBirthdateBefore(LocalDate birthdate);
+
+//  @Query("select c from Customer c where c.state = :state")
+//  List<CustomerEntity> findSomething(@Param("state") CustomerState state);
+
+}

--- a/src/main/java/com/samples/customers/persistence/CustomerStateConverter.java
+++ b/src/main/java/com/samples/customers/persistence/CustomerStateConverter.java
@@ -1,0 +1,29 @@
+package com.samples.customers.persistence;
+
+import com.samples.customers.domain.CustomerState;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class CustomerStateConverter
+  implements AttributeConverter<CustomerState, String> {
+
+  @Override
+  public String convertToDatabaseColumn(CustomerState attribute) {
+    return null == attribute ? null : switch (attribute) {
+      case ACTIVE -> "a";
+      case LOCKED -> "l";
+      case DISABLED -> "d";
+    };
+  }
+
+  @Override
+  public CustomerState convertToEntityAttribute(String dbData) {
+    return null == dbData ? null : switch (dbData) {
+      case "a" -> CustomerState.ACTIVE;
+      case "l" -> CustomerState.LOCKED;
+      case "d" -> CustomerState.DISABLED;
+      default -> throw new IllegalStateException("Unexpected value: " + dbData);
+    };
+  }
+}

--- a/src/main/java/com/samples/customers/persistence/JpaCustomersSink.java
+++ b/src/main/java/com/samples/customers/persistence/JpaCustomersSink.java
@@ -1,0 +1,56 @@
+package com.samples.customers.persistence;
+
+import com.samples.customers.domain.Customer;
+import com.samples.customers.domain.CustomersSink;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+@Component
+@RequiredArgsConstructor
+public class JpaCustomersSink implements CustomersSink {
+
+  private final CustomerEntityMapper mapper;
+  private final CustomerEntityRepository repo;
+
+  @Override
+  public Stream<Customer> findAll() {
+    return repo
+      .findAll()
+      .stream()
+      .map(mapper::map);
+  }
+
+  @Override
+  public Optional<Customer> findById(UUID id) {
+    return repo
+      .findById(id)
+      .map(mapper::map);
+  }
+
+  @Override
+  public void create(Customer customer) {
+    var entity = mapper.map(customer);
+    repo.save(entity);
+    // customer.setUuid(entity.getUuid());
+    mapper.copy(entity, customer);
+  }
+
+  @Override
+  public boolean existsById(UUID id) {
+    return repo.existsById(id);
+  }
+
+  @Override
+  public void delete(UUID id) {
+    repo.deleteById(id);
+  }
+
+  @Override
+  public long count() {
+    return repo.count();
+  }
+}

--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -1,0 +1,6 @@
+# In Cloud: Umgebungsvariablen
+spring:
+  datasource:
+    url: ${DS_URL}
+    username: ${DS_USER}
+    password: ${DS_PASSWORD}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,3 +5,13 @@ application:
     allowed-origins: '*.swagger.io'
   initialization:
     enabled: true
+spring:
+  datasource:
+    url: jdbc:h2:./.local-db/customers
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+  h2:
+    console:
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,9 @@ spring:
     deserialization:
       fail-on-unknown-properties: true
       fail-on-ignored-properties: true
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  h2:
+    console:
+      enabled: false

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -11,6 +11,7 @@
 <h2>Resources in this application</h2>
 <ul>
   <li><a href="openapi.yml">OpenAPI</a></li>
+  <li><a href="h2-console">H2 Console</a></li>
 </ul>
 </body>
 </html>

--- a/src/test/java/com/samples/customers/boundary/ApiTests.java
+++ b/src/test/java/com/samples/customers/boundary/ApiTests.java
@@ -4,9 +4,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
@@ -25,6 +27,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
 class ApiTests {
 
   @Autowired

--- a/src/test/java/com/samples/customers/boundary/ApiWithMockedDomainTests.java
+++ b/src/test/java/com/samples/customers/boundary/ApiWithMockedDomainTests.java
@@ -3,9 +3,11 @@ package com.samples.customers.boundary;
 import com.samples.customers.domain.CustomersService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -21,6 +23,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
 public class ApiWithMockedDomainTests {
 
   @Autowired

--- a/src/test/java/com/samples/customers/boundary/CorsTests.java
+++ b/src/test/java/com/samples/customers/boundary/CorsTests.java
@@ -2,9 +2,11 @@ package com.samples.customers.boundary;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
@@ -17,6 +19,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
   }
 )
 @AutoConfigureMockMvc
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
 class CorsTests {
 
   @Autowired

--- a/src/test/java/com/samples/customers/boundary/StaticResourcesTests.java
+++ b/src/test/java/com/samples/customers/boundary/StaticResourcesTests.java
@@ -2,9 +2,11 @@ package com.samples.customers.boundary;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -13,6 +15,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
 class StaticResourcesTests {
 
   @Autowired

--- a/src/test/java/com/samples/customers/domain/CustomersInitializerTests.java
+++ b/src/test/java/com/samples/customers/domain/CustomersInitializerTests.java
@@ -2,7 +2,9 @@ package com.samples.customers.domain;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,6 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
   }
 )
 //@ActiveProfiles("dev")
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
 class CustomersInitializerTests {
 
   @Autowired

--- a/src/test/java/com/samples/customers/domain/CustomersServiceTests.java
+++ b/src/test/java/com/samples/customers/domain/CustomersServiceTests.java
@@ -3,13 +3,17 @@ package com.samples.customers.domain;
 import jakarta.validation.ValidationException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
+@AutoConfigureTestDatabase
+@ActiveProfiles("test")
 class CustomersServiceTests {
 
   @Autowired

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,5 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true


### PR DESCRIPTION
# Weiterführende Informationen

- [Beispiel für JPA Entities mit Relationen](https://github.com/ralf-ueberfuhr-ars/spring-data-2023-05-09/tree/main/src/main/java/de/sample/spring/customers/entities)
- Fallstricke bei JPA:
    - Mapping von Enums
    - 1:n/m:n-Beziehungen werden Lazy (bei Aufruf des Getters) geladen, falls nicht explizit per `FetchType` anders angegeben
      - Vorsicht bei `hashCode()`/`equals()`/`toString()`, v.a. wenn von Lombok generiert - dann per Lombok-Annotation ausschließen
      - Vorsicht bei MapStruct-Mappern
    - 1:1/n:1-Beziehungen werden Eager (sofort) geladen, falls nicht explizit per `FetchType` anders angegeben
      - Vorsicht bei großen Daten (CLOBs, BLOBs)